### PR TITLE
Hook Controller Input

### DIFF
--- a/Game.hpp
+++ b/Game.hpp
@@ -6,6 +6,7 @@ namespace FF7Remake {
 
 	struct Offsets {
 		int aStatsPTR = 0x057A57E8;
+		int aXinputState = 0x1D1F870;
 		std::vector<unsigned int> oCloud = { 0x880 };
 		std::vector<unsigned int> oParty2 = { 0x8C0 };
 		std::vector<unsigned int> oParty3 = { 0x900 };

--- a/Hooking.cpp
+++ b/Hooking.cpp
@@ -6,19 +6,30 @@ namespace FF7Remake {
 #if DEBUG
 		g_Console->printdbg("Hooking::Initialized\n", g_Console->color.pink);
 #endif
+		m_ControllerInputHandle = (og_GameBase + g_GameData->offsets.aXinputState);
 		return;
 	}
 
-	Hooking::~Hooking()
+	void Hooking::HookControllerInput(INT64 a1)
 	{
-		MH_RemoveHook(MH_ALL_HOOKS);
+		//	Whenever the menu is shown , we wont pass controller inputs to the game
+		if (g_GameVariables->m_ShowMenu)
+			return;
+
+		reinterpret_cast<decltype(&HookControllerInput)>(g_Hooking->m_OriginalCInputHandle)(a1);
 	}
 
 	void Hooking::Hook()
 	{
 		g_GameVariables->Init();
 		g_D3D11Window->Hook();
+
+		//	Controller Input Handler
+		if (m_ControllerInputHandle)
+			MH_CreateHook((LPVOID)m_ControllerInputHandle, &HookControllerInput, &m_OriginalCInputHandle);
+
 		MH_EnableHook(MH_ALL_HOOKS);
+
 #if DEBUG
 		g_Console->printdbg("Hooking::Hook Initialized\n", g_Console->color.pink);
 #endif
@@ -31,5 +42,10 @@ namespace FF7Remake {
 		MH_RemoveHook(MH_ALL_HOOKS);
 		g_Console->DestroyConsole();
 		return;
+	}
+
+	Hooking::~Hooking()
+	{
+		MH_RemoveHook(MH_ALL_HOOKS);
 	}
 }

--- a/Hooking.hpp
+++ b/Hooking.hpp
@@ -18,6 +18,10 @@ namespace FF7Remake {
 
 		void Hook();
 		void Unhook();
+
+		static void __fastcall HookControllerInput(INT64 a1);
+		void* m_OriginalCInputHandle{};
+		uint64_t m_ControllerInputHandle{};
 	};
 	inline std::unique_ptr<Hooking> g_Hooking;
 }


### PR DESCRIPTION
Basically whenever the menu is shown we will prevent gamepad inputs from being sent to the game.
Much like we do with mouse inputs and keyboard inputs.