### PR TITLE
Update game memory offsets and comments

### DIFF
--- a/Source.cpp
+++ b/Source.cpp
@@ -4,9 +4,9 @@ VOID WINAPI BackgroundThread()
 {
     while (g_bRunning)
     {
-        DX11Base::Menu::Loops();
+        DX11Base::Menu::Loops(); // menu background tasks
 
-        if (g_bKillswitch)
+        if (g_bKillswitch) // exit loop
         {
            FF7Remake::AGame::ShutdownGame();
             DX11Base::g_Hooking->Shutdown();
@@ -25,6 +25,7 @@ DWORD WINAPI MainThread(LPVOID hInstance)
 {
     UNREFERENCED_PARAMETER(hInstance);
 
+    // @TODO: check for errors
     DX11Base::g_Engine = std::make_unique<DX11Base::Engine>();
     DX11Base::g_Console->InitializeConsole("Final Fantasy 7 Remake : Debug Console", true);      //  initialize console without menu gui
     DX11Base::g_Engine->Init();                                                                   //  Get Process Information

--- a/include/Game.h
+++ b/include/Game.h
@@ -23,30 +23,30 @@ namespace FF7Remake
 	namespace Offsets
 	{
 		constexpr auto						gObjects{ 0x539e410 };					//	48 8D 05 ? ? ? ? C7 05 ? ? ? ? ? ? ? ? 48 8D 0D ? ? ? ? 48 89 05 ? ? ? ? 48 83 C4
-		constexpr auto						oGameBase{ 0x57CA5E0 };					//	 : subtract 0x8 from the qword for oGameState
-		constexpr auto						oGameState{ 0x57CA5E0 };				//	48 8B 05 ? ? ? ? 4C 89 B4 24 ? ? ? ? 44 0F B6 76
+		constexpr auto						oGameBase{ 0x57E8DE0 };					//	 : subtract 0x8 from the qword for oGameState
+		constexpr auto						oGameState{ 0x57E8DE8 };				//	48 8B 05 ? ? ? ? 4C 89 B4 24 ? ? ? ? 44 0F B6 76
 		constexpr auto						oGameBase_CloudState{ 0x880 };			//	Analyze APlayerState_SetHealth_hook
 		constexpr auto						oGameBase_ItemsList{ 0x35640 };			//	Analyze APlayerState_SubItem_hook
-		constexpr auto						oGameBase_MateriaList{ 0x20A8 };		//	
+		constexpr auto						oGameBase_MateriaList{ 0x20A8 };		//	? ? ?
 	};
 
 	namespace FunctionOffsets
 	{
-		constexpr auto						fnXinputState{ 0x1D253A0 };				//	XInput_State_hook			; FF 15 ? ? ? ? 85 C0 0F 94 C1 - 0x8E	; __int64 __fastcall x__XInput_UpdateState(__int64)
-		constexpr auto						fnSceneUpdate{ 0x16B9510 };				//	AScene_Update_hook			;	E8 ? ? ? ? 48 8B 0D ? ? ? ? 48 8B 89 ? ? ? ? 48 83 C4	; __int64 __fastcall x__AScene_Update(__int64)
-		constexpr auto						fnSetHealth{ 0x0AFDF80 };				//	APlayerState_SetHealth_hook	;	E8 ? ? ? ? 0F B6 CB E8 ? ? ? ? 8B D0	; __int64 __fastcall x__APlayerState_SubHealth(unsigned __int8, int)
-		constexpr auto						fnSetMana{ 0x0AFE190 };					//	APlayerState_SetMana_hook	;	E8 ? ? ? ? 48 83 C6 ? 48 3B F5 0F 85 ? ? ? ? 4C 8B 74 24 ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 83 C4	; __int64 __fastcall x__APlayerState_SetMana(unsigned __int8, int)
-		constexpr auto						fnSubItem{ 0x0B1F410 };					//	APlayerState_SubItem_hook	;	E8 ? ? ? ? B0 ? EB ? CC CC CC CC CC CC CC 48 89 5C 24 ? 57	; __int64 __fastcall x__APlayerState_SubItem(__int64, int)
-		constexpr auto						fnTargetGetHP{ 0x0889710 };				//	ATargetEntity_GetHP_hook	;	E8 ? ? ? ? 8B C8 88 45 ? C1 F9 ? 48 8D 55 ? 88 4D ? 41 B8 ? ? ? ? 8B C8 C1 F8 ? C1 F9 ? 88 45 ? 48 8B 07 88 4D ? 48 8B CF FF 50 ? 48 8B 5C 24	; __int64 __fastcall x__ATargetEntity_GetHP(__int64)
-		constexpr auto						fnTargetGetStaggerAmount{ 0x0891870 };	//	ATargetEntity_GetStaggerAmount_hook	;	48 8B 05 ? ? ? ? 48 39 41 ? 0F 94 C0 + 0x16	; float __fastcall x__ATargetEntity_GetStaggerAmount(__int64)
-		constexpr auto                      fnGetHighlitedEquipment{ 0x0AFF020 };	//	GetHighlitedEquipment_hook	;	E8 ? ? ? ? 8B 85 ? ? ? ? 44 8B 8D ? ? ? ? 44 8B 85	; __int64 __fastcall _GetHighlitedEquipment(_QWORD *, __int64)
-		constexpr auto						vfGetEquipmentByID{ 0x1996E80 };		//	vfGetEquipmentByID_hook		; __int64 __fastcall _vfGetEquipmentByID(__int64 a1, __int64 eqID)
-		constexpr auto						fnSetGil{ 0xB232E0 };					//	AGameState_SetGil_hook		;	E8 ? ? ? ? 49 8B 87 ? ? ? ? 48 8B 88 ? ? ? ? 48 85 C9 74 ? 48 8B 89 ? ? ? ? E8 ? ? ? ? C7 45 ? ? ? ? ? 48 8D 0D ? ? ? ? 48 89 4D ? 48 8D 55 ? 0F 28 45 ? 66 0F 7F 45 ? E8 ? ? ? ? 8B 4D ? 8B D8	;	void __fastcall x__SetGil(__int64 a1, int newCount)
+		constexpr auto						fnXinputState{ 0x1D2EFB0 };				//	XInput_State_hook			;	FF 15 ? ? ? ? 85 C0 0F 94 C1 - 0x8E	or xref "xinput::GetState" ; __int64 __fastcall x__XInput_UpdateState(__int64)
+		constexpr auto						fnSceneUpdate{ 0x16C0CA0 };				//	AScene_Update_hook			;	E8 ? ? ? ? 48 8B 0D ? ? ? ? 48 8B 89 ? ? ? ? 48 83 C4	; __int64 __fastcall x__AScene_Update(__int64)
+		constexpr auto						fnSetHealth{ 0x0B011C0 };				//	APlayerState_SetHealth_hook	;	E8 ? ? ? ? 0F B6 CB E8 ? ? ? ? 8B D0	; __int64 __fastcall x__APlayerState_SubHealth(unsigned __int8, int)
+		constexpr auto						fnSetMana{ 0x0B013D0 };					//	APlayerState_SetMana_hook	;	E8 ? ? ? ? 48 83 C6 ? 48 3B F5 0F 85 ? ? ? ? 4C 8B 74 24 ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 83 C4	; __int64 __fastcall x__APlayerState_SetMana(unsigned __int8, int)
+		constexpr auto						fnSubItem{ 0x0B22DD0 };					//	APlayerState_SubItem_hook	;	E8 ? ? ? ? B0 ? EB ? CC CC CC CC CC CC CC 48 89 5C 24 ? 57	; __int64 __fastcall x__APlayerState_SubItem(__int64, int)
+		constexpr auto						fnTargetGetHP{ 0x088C440 };				//	ATargetEntity_GetHP_hook	;	E8 ? ? ? ? 8B C8 88 45 ? C1 F9 ? 48 8D 55 ? 88 4D ? 41 B8 ? ? ? ? 8B C8 C1 F8 ? C1 F9 ? 88 45 ? 48 8B 07 88 4D ? 48 8B CF FF 50 ? 48 8B 5C 24	; __int64 __fastcall x__ATargetEntity_GetHP(__int64)
+		constexpr auto						fnTargetGetStaggerAmount{ 0x08945A0 };	//	ATargetEntity_GetStaggerAmount_hook	;	48 8B 05 ? ? ? ? 48 39 41 ? 0F 94 C0 + 0x16	; float __fastcall x__ATargetEntity_GetStaggerAmount(__int64)
+		constexpr auto                      fnGetHighlitedEquipment{ 0x0B02260 };	//	GetHighlitedEquipment_hook	;	E8 ? ? ? ? 8B 85 ? ? ? ? 44 8B 8D ? ? ? ? 44 8B 85	; __int64 __fastcall _GetHighlitedEquipment(_QWORD *, __int64)
+		constexpr auto						vfGetEquipmentByID{ 0x19A0400 };		//	vfGetEquipmentByID_hook		; E8 ? ? ? ? 4C 63 45 ? 41 83 F8 ? 74 ? 49 8B C0 48 C1 E0 ? 48 03 03 EB xref and scroll to bottom result will be offset +15 and the following xref will be +265 __int64 __fastcall _vfGetEquipmentByID(__int64 a1, __int64 eqID)
+		constexpr auto						fnSetGil{ 0x0B26DD0 };					//	AGameState_SetGil_hook		;	E8 ? ? ? ? 49 8B 87 ? ? ? ? 48 8B 88 ? ? ? ? 48 85 C9 74 ? 48 8B 89 ? ? ? ? E8 ? ? ? ? C7 45 ? ? ? ? ? 48 8D 0D ? ? ? ? 48 89 4D ? 48 8D 55 ? 0F 28 45 ? 66 0F 7F 45 ? E8 ? ? ? ? 8B 4D ? 8B D8	;	void __fastcall x__SetGil(__int64 a1, int newCount)
 	}
 
 	namespace VtableOffsets
 	{
-		constexpr auto						vfTargetEntity{ 0x4B4E128 };			//  Analyze ATargetEntity_GetHP_hook	;	48 8D 0D ? ? ? ? 48 89 78 ? 48 89 08 48 89 78	
+		constexpr auto						vfTargetEntity{ 0x4B6B300 };			//  xref ATargetEntity_GetHP_hook	;	48 8D 0D ? ? ? ? 48 89 78 ? 48 89 08 48 89 78	
 	}
 
 	


### PR DESCRIPTION
Updated multiple in-game memory offsets and vtable entries in include/Game.h to new addresses (oGameBase, oGameState, numerous FunctionOffsets like fnXinputState, fnSceneUpdate, fnSetHealth/fnSetMana/fnSubItem, fnTargetGetHP, fnTargetGetStaggerAmount, fnGetHighlitedEquipment, vfGetEquipmentByID, fnSetGil, and vfTargetEntity). These align the hook/injection points with a new game build. Also added small non-functional comments in Source.cpp (menu background task note, killswitch exit comment) and a TODO to check for errors before engine initialization. No behavioral logic was changed beyond the updated offsets and inline annotations.